### PR TITLE
Primitive Types 🔨 Puzzles 🧩 Pt. 3

### DIFF
--- a/episodes/00_Introduction/00_Agenda.txt
+++ b/episodes/00_Introduction/00_Agenda.txt
@@ -20,7 +20,7 @@ Scenarios:
                 1   Example Scenario
 
 Puzzles:
-                A   Example Puzzle
+                A   Example_Puzzle
 
 References:
                 -   Visual Studio https://code.visualstudio.com/

--- a/episodes/00_Introduction/puzzles/Introduction_A.sol
+++ b/episodes/00_Introduction/puzzles/Introduction_A.sol
@@ -5,7 +5,7 @@ import "utils/Puzzle.sol";
 
 // NOTE This puzzle is solved by assigning the value 1 to "a" and the value 2 to "b"
 
-contract Simple {
+contract Example_Puzzle {
 
     // ---------------------
     //    State Variables

--- a/episodes/02_Primitive_Types/02_Agenda.txt
+++ b/episodes/02_Primitive_Types/02_Agenda.txt
@@ -24,8 +24,13 @@ Scenarios:
                 5  Fixed-size Byte Arrays (bytes4, bytes32)
 
 Puzzles:
-                A   GreatedGood
-                B   TakeItToTheLimit
+                A   Greated_Good
+                B   Take_It_To_The_Limit
+                C   Lost
+                D   Turn_Me_On
+                E   Pet_Rock
+
+TODO Consider puzzle names with underscores for readability
 
 References:
                 - Null Address: https://etherscan.io/address/0x0000000000000000000000000000000000000000

--- a/episodes/02_Primitive_Types/02_Agenda.txt
+++ b/episodes/02_Primitive_Types/02_Agenda.txt
@@ -27,4 +27,5 @@ Puzzles:
                 A   GreatedGood
                 B   TakeItToTheLimit
 
-References:     None
+References:
+                - Null Address: https://etherscan.io/address/0x0000000000000000000000000000000000000000

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_A.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_A.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.17;
 import "utils/Puzzle.sol";
 
 // NOTE To solve this puzzle, assign a value in-line to "b" which is greater than the value of "a"
-// NOTE This requires modifying one line in the GreaterGood contract
+// NOTE This requires modifying one line in the Greater_Good contract
 
-contract GreaterGood {
+contract Greater_Good {
 
     // ---------------------
     //    State Variables
@@ -19,14 +19,14 @@ contract GreaterGood {
 
 contract Primitive_Types_A is Puzzle {
 
-    // Declare a GreaterGood contract variable, "GG"
+    // Declare a Greater_Good contract variable, "GG"
 
-    GreaterGood GG;
+    Greater_Good GG;
 
-    // Initialize the variable "GG" with a new GreaterGood contract
+    // Initialize the variable "GG" with a new Greater_Good contract
 
     function setUp() public {
-        GG = new GreaterGood();
+        GG = new Greater_Good();
     }
 
     // Validate state variable "b" is greater than state variable "a"

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_B.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_B.sol
@@ -6,7 +6,7 @@ import "utils/Puzzle.sol";
 // NOTE To solve this puzzle, assign each state variable its maximum value (in-line)
 // NOTE This will require modifying exactly 5 lines below
 
-contract TakeItToTheLimit {
+contract Take_It_To_The_Limit {
 
     // ---------------------
     //    State Variables
@@ -22,14 +22,14 @@ contract TakeItToTheLimit {
 
 contract Primitive_Types_B is Puzzle {
 
-    // Declare a TakeItToTheLimit contract variable, "SCAR"
+    // Declare a Take_It_To_The_Limit contract variable, "SCAR"
 
-    TakeItToTheLimit SCAR;
+    Take_It_To_The_Limit SCAR;
 
-    // Initialize the variable with a new TakeItToTheLimit contract 
+    // Initialize the variable with a new Take_It_To_The_Limit contract 
 
     function setUp() public {
-        SCAR = new TakeItToTheLimit();
+        SCAR = new Take_It_To_The_Limit();
     }
 
     // Validate each state variable has the correct value

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_C.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_C.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 import "utils/Puzzle.sol";
 
-// NOTE To solve this puzzle, assign the value "whereAreWe" to the address of the contract
+// NOTE To solve this puzzle, assign the value "whereAreWe" to the address of the contract Lost
 
 contract Lost {
 
@@ -27,7 +27,7 @@ contract Primitive_Types_C is Puzzle {
         LOST = new Lost();
     }
 
-    // Validate that the variable "whereAreWe" is equal to the address of the contract
+    // Validate that the variable "whereAreWe" is equal to the address of the LOST contract
 
     function test_P_Primitive_Types_C1() public {
         assertEq(LOST.whereAreWe(), address(LOST));

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_C.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_C.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.17;
+
+import "utils/Puzzle.sol";
+
+// NOTE To solve this puzzle, assign the value "whereAreWe" to the address of the contract
+
+contract Lost {
+
+    // ---------------------
+    //    State Variables
+    // ---------------------
+
+    address public whereAreWe = address(0);
+
+}
+
+contract Primitive_Types_C is Puzzle {
+
+    // Declare a Lost contract variable, "LOST"
+
+    Lost LOST;
+
+    // Initialize the variable "LOST" with a new Lost contract
+
+    function setUp() public {
+        LOST = new Lost();
+    }
+
+    // Validate that the variable "whereAreWe" is equal to the address of the contract
+
+    function test_P_Primitive_Types_C1() public {
+        assertEq(LOST.whereAreWe(), address(LOST));
+    }
+
+}

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_D.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_D.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.17;
+
+import "utils/Puzzle.sol";
+
+// NOTE To solve this puzzle, turn this contract on
+
+contract TurnMeOn {
+
+    // ---------------------
+    //    State Variables
+    // ---------------------
+
+    bool public on;
+
+}
+
+contract Primitive_Types_D is Puzzle {
+
+    // Declare a TurnMeOn contract variable, "LIGHT"
+
+    TurnMeOn LIGHT;
+
+    // Initialize the variable "LIGHT" with a new TurnMeOn contract
+
+    function setUp() public {
+        LIGHT = new TurnMeOn();
+    }
+
+    // Validate that the contract is turned on (the variable "on" is true)
+
+    function test_P_Primitive_Types_C1() public {
+        assert(LIGHT.on());
+    }
+
+}

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_D.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_D.sol
@@ -5,7 +5,7 @@ import "utils/Puzzle.sol";
 
 // NOTE To solve this puzzle, turn this contract on
 
-contract TurnMeOn {
+contract Turn_Me_On {
 
     // ---------------------
     //    State Variables
@@ -17,14 +17,14 @@ contract TurnMeOn {
 
 contract Primitive_Types_D is Puzzle {
 
-    // Declare a TurnMeOn contract variable, "LIGHT"
+    // Declare a Turn_Me_On contract variable, "LIGHT"
 
-    TurnMeOn LIGHT;
+    Turn_Me_On LIGHT;
 
-    // Initialize the variable "LIGHT" with a new TurnMeOn contract
+    // Initialize the variable "LIGHT" with a new Turn_Me_On contract
 
     function setUp() public {
-        LIGHT = new TurnMeOn();
+        LIGHT = new Turn_Me_On();
     }
 
     // Validate that the contract is turned on (the variable "on" is true)

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_D.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_D.sol
@@ -29,7 +29,7 @@ contract Primitive_Types_D is Puzzle {
 
     // Validate that the contract is turned on (the variable "on" is true)
 
-    function test_P_Primitive_Types_C1() public {
+    function test_P_Primitive_Types_D1() public {
         assert(LIGHT.on());
     }
 

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_E.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_E.sol
@@ -21,7 +21,7 @@ contract Primitive_Types_E is Puzzle {
 
     Pet_Rock ROCK;
 
-    // Initialize the variable "LIGHT" with a new TurnMeOn contract
+    // Initialize the variable "ROCK" with a new Pet_Rock contract
 
     function setUp() public {
         ROCK = new Pet_Rock();

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_E.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_E.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.17;
 
 import "utils/Puzzle.sol";
 
-// NOTE To solve this puzzle, use the smallest fixed-size bytes possible for the PetRock "name"
+// NOTE To solve this puzzle, use the smallest fixed-size bytes possible for the Pet_Rock "name"
 
-contract PetRock {
+contract Pet_Rock {
 
     // ---------------------
     //    State Variables
@@ -17,14 +17,14 @@ contract PetRock {
 
 contract Primitive_Types_E is Puzzle {
 
-    // Declare a PetRock contract variable, "ROCK"
+    // Declare a Pet_Rock contract variable, "ROCK"
 
-    PetRock ROCK;
+    Pet_Rock ROCK;
 
     // Initialize the variable "LIGHT" with a new TurnMeOn contract
 
     function setUp() public {
-        ROCK = new PetRock();
+        ROCK = new Pet_Rock();
     }
 
     // Validate that the variable "name" is the smallest fixed-size bytes type

--- a/episodes/02_Primitive_Types/puzzles/Primitive_Types_E.sol
+++ b/episodes/02_Primitive_Types/puzzles/Primitive_Types_E.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.17;
+
+import "utils/Puzzle.sol";
+
+// NOTE To solve this puzzle, use the smallest fixed-size bytes possible for the PetRock "name"
+
+contract PetRock {
+
+    // ---------------------
+    //    State Variables
+    // ---------------------
+
+    bytes16 public name = 'Timmy';
+
+}
+
+contract Primitive_Types_E is Puzzle {
+
+    // Declare a PetRock contract variable, "ROCK"
+
+    PetRock ROCK;
+
+    // Initialize the variable "LIGHT" with a new TurnMeOn contract
+
+    function setUp() public {
+        ROCK = new PetRock();
+    }
+
+    // Validate that the variable "name" is the smallest fixed-size bytes type
+
+    function test_P_Primitive_Types_E1() public {
+        bytes memory encodedName = abi.encodePacked(ROCK.name());
+        assert(encodedName.length == 5);
+    }
+
+}

--- a/episodes/02_Primitive_Types/scenarios/Primitive_Types_3.sol
+++ b/episodes/02_Primitive_Types/scenarios/Primitive_Types_3.sol
@@ -5,41 +5,45 @@ import "utils/Scenario.sol";
 
 // TODO Explain the address type
 
-// TODO Explain the basics of typecasting in this scenario
-// TODO Create a typecasting episode
-
 contract Home {
 
     // ---------------------
     //    State Variables
     // ---------------------
 
-    // The default value of an address is 0x0000000000000000000000000000000000000000
-    // The default value of an address is address(0)
+    // The default value of an address is 0x0000000000000000000000000000000000000000, or simply address(0)
+    // You can view the contents of the null address on EtherScan:
+    // https://etherscan.io/address/0x0000000000000000000000000000000000000000
+
     address public nowhere;
 
-    // Values can be assigned in two different forms:
-    // The compiler requires address values to be typecasted
 
-    // TODO Discuss typecasting briefly, mention the future episode covering it
+    // Values can be assigned to address types in a few different ways:
 
-    address public longWay  = address(0x0000000000000000000000000000000000042A);     // Typecasted
+    address public longWay  = 0x000000000000000000000000000000000000042A;   // Address literal, checksummed
+
+    address public shortWay = address(0x42A);                               // Typecast
+
+    // Fetch the address of the current contract using address(this)
+    // The variable "this" refers to the current contract, and in this case we're fetching the adress with typecasting
+
+    address public heart = address(this);
+
+
+    // In Solidity, there are primarily two types of addresses: 
+    //  - Externally Owned Accounts (EOA)
+    //  - Contract Addresses (CA)
+
+    // These two types of addresses serve different purposes.
+
+    // Externally Owned Accounts have a public key (their address) and a private key.
+    // These addresses are controlled by individuals that have the private key to authenticate transactions.
+    // For example, when using MetaMask you generate a private key and a public key.
+
+    // Contract Addresses have only a public key (their address), they do not have a private key.
+    // These addresses are controlled by the code within them (other addresses can interact with the code).
+    // For example, this contract.
     
-    address public shortWay = address(0x42A);                               
-
-    // Fetch the address of the current contract using address(this).
-    address public something = address(this);
-
-    // TODO Explain what "this" is, what other components it has
-
-    // The address type has 3 accessible properties:
-    //   .balance
-    //   .code
-    //   .codehash
-
-    // address.balance  - represents the amount of ether (ETH) owned by this address
-    // address.code     - representing the code of the deployed contract (rarely used))
-    // address.codehash - representing a hash of the code of the deployed contract (rarely used)
 
 }
 
@@ -67,29 +71,13 @@ contract Primitive_Types_3 is Scenario {
         assertEq(HOME.longWay(),    HOME.shortWay());
     }
 
-    // Validate that address(HOME) and HOME.something() have the same value
+    // Validate that address(HOME) and HOME.heart() have the same value
     // Notice that in order to fetch the address of a contract state variable, we typecast it with address()
 
     function test_Primitive_Types_3C() public {
         emit Log("address(HOME)",   address(HOME));
-        emit Log("HOME.something()", HOME.something());
-        assertEq(address(HOME),      HOME.something());
-    }
-
-    // All contracts inheriting Scenario / Puzzles receive large amount of Ether
-    // For more in-depth information, see the EVM Fundamentals (#15) & Payable Modifier (#16) episodes
-
-    function test_Primitive_Types_3D() public {
-        emit Log("address(this).balance", address(this).balance);
-    }
-
-    // For more in-depth information, see the EVM Fundamentals (#15) & Payable Modifier (#16) episodes
-    // Use .code to get the EVM bytecode as a bytes memory, which might be empty. 
-    // Use .codehash to get the keccak-256 hash of that code (as a bytes32).
-
-    function test_Primitive_Types_3E() public {
-        emit Log("address(HOME).code", address(HOME).code);
-        emit Log("address(HOME).codehash", address(HOME).codehash);
+        emit Log("HOME.heart()",    HOME.heart());
+        assertEq(address(HOME),     HOME.heart());
     }
 
 }

--- a/episodes/02_Primitive_Types/scenarios/Primitive_Types_5.sol
+++ b/episodes/02_Primitive_Types/scenarios/Primitive_Types_5.sol
@@ -12,7 +12,7 @@ contract ByteMe {
     // ---------------------
     
     // Fixed-size byte arrays are initialized with a # between 1 and 32 following the word bytes
-    // NOTE The type "bytes" (without a number) is not fixed-size, but rather dynamic (covered in another episode)
+    // The type "bytes" (without a number) is not fixed-size, but rather dynamic (covered in Dynamic Types)
 
     bytes1 public smallest;
     bytes32 public largest;
@@ -32,12 +32,6 @@ contract ByteMe {
 
     // Attempting to assign a fixed-size beyond 32 is not supported:
     // bytes33 public overloaded = 'abcdefghijklmnopqrstuvwxyz0123456';
-
-    // TODO Consider hexadecimal literals (as a type) to assign a value to bytes4 ... converts from hex to bytes
-
-    // Assigning numbers or hexadecimals is not supported:
-    // bytes4 public oneHex = 0x45;
-    // bytes4 public oneHex = 8;
 
 }
 

--- a/episodes/02_Primitive_Types/scenarios/Primitive_Types_5.sol
+++ b/episodes/02_Primitive_Types/scenarios/Primitive_Types_5.sol
@@ -50,15 +50,15 @@ contract Primitive_Types_5 is Scenario {
     }
 
     function test_Primitive_Types_5A() public {
-        emit Log("BYTE.smallest()", BYTE.smallest());
-        emit Log("BYTE.largest()", BYTE.largest());
-        emit Log("BYTE.oneByte()", BYTE.oneByte());
-        emit Log("BYTE.twoBytes()", BYTE.twoBytes());
-        emit Log("BYTE.threeBytes()", BYTE.threeBytes());
-        emit Log("BYTE.eightBytes()", BYTE.eightBytes());
+        emit Log("BYTE.smallest()",     BYTE.smallest());
+        emit Log("BYTE.largest()",      BYTE.largest());
+        emit Log("BYTE.oneByte()",      BYTE.oneByte());
+        emit Log("BYTE.twoBytes()",     BYTE.twoBytes());
+        emit Log("BYTE.threeBytes()",   BYTE.threeBytes());
+        emit Log("BYTE.eightBytes()",   BYTE.eightBytes());
         emit Log("BYTE.sixteenBytes()", BYTE.sixteenBytes());
-        emit Log("BYTE.alphabet()", BYTE.alphabet());
-        emit Log("BYTE.enchilada()", BYTE.enchilada());
+        emit Log("BYTE.alphabet()",     BYTE.alphabet());
+        emit Log("BYTE.enchilada()",    BYTE.enchilada());
     }
 
 }

--- a/episodes/03_Constructor/03_Agenda.txt
+++ b/episodes/03_Constructor/03_Agenda.txt
@@ -23,7 +23,8 @@ Scenarios:
                 4   Variable Scoping TODO
 
 Puzzles:
-                A   Push My Buttons
-                B   Black Mirror
+                A   Push_My_Buttons
+                B   Black_Mirror
+                C   The_Meaning_Of_Life
 
 References:     None

--- a/episodes/03_Constructor/puzzles/Constructor_A.sol
+++ b/episodes/03_Constructor/puzzles/Constructor_A.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.17;
 
 import "utils/Puzzle.sol";
 
-// NOTE To solve this puzzle, initialize the contract "Push_My_Buttons" such that 
-//      its state variables "a" == 1 and "b" == 2.
+// NOTE To solve this puzzle, initialize the variable "PMB" such that the Push_My_Butons contract
+//      has state variables "a" == 1 and "b" == 2.
 
 contract Push_My_Buttons {
 

--- a/episodes/03_Constructor/puzzles/Constructor_A.sol
+++ b/episodes/03_Constructor/puzzles/Constructor_A.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.17;
 
 import "utils/Puzzle.sol";
 
-// NOTE To solve this puzzle, initialize the contract "PushMyButtons" such that 
+// NOTE To solve this puzzle, initialize the contract "Push_My_Buttons" such that 
 //      its state variables "a" == 1 and "b" == 2.
 
-contract PushMyButtons {
+contract Push_My_Buttons {
 
     // ---------------------
     //    State Variables
@@ -30,7 +30,7 @@ contract PushMyButtons {
 
 contract Constructor_A is Puzzle {
 
-    PushMyButtons PMB;
+    Push_My_Buttons PMB;
 
     function setUp() public {
 

--- a/episodes/03_Constructor/puzzles/Constructor_B.sol
+++ b/episodes/03_Constructor/puzzles/Constructor_B.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 import "utils/Puzzle.sol";
 
-contract BlackMirror {
+contract Black_Mirror {
 
     // ---------------------
     //    State Variables
@@ -26,10 +26,10 @@ contract BlackMirror {
 
 contract Constructor_B is Puzzle {
 
-    BlackMirror BM;
+    Black_Mirror BM;
 
     function setUp() public {
-        BM = new BlackMirror();
+        BM = new Black_Mirror();
     }
 
     // Validate the value of "a"

--- a/episodes/03_Constructor/puzzles/Constructor_C.sol
+++ b/episodes/03_Constructor/puzzles/Constructor_C.sol
@@ -5,7 +5,7 @@ import "utils/Puzzle.sol";
 
 // NOTE To solve this puzzle, you must think deeply about deploying new contracts, and the meaning of life
 
-contract TheMeaningOfLife {
+contract The_Meaning_Of_Life {
 
     // ---------------------
     //    State Variables
@@ -27,10 +27,10 @@ contract TheMeaningOfLife {
 
 contract Constructor_C is Puzzle {
 
-    TheMeaningOfLife LIFE;
+    The_Meaning_Of_Life LIFE;
 
     function setUp() public {
-        LIFE = TheMeaningOfLife(address(42));
+        LIFE = The_Meaning_Of_Life(address(42));
     }
 
     // Validate that the meaning of "life" is 42

--- a/episodes/03_Constructor/puzzles/Constructor_C.sol
+++ b/episodes/03_Constructor/puzzles/Constructor_C.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 import "utils/Puzzle.sol";
 
-// NOTE To solve this puzzle, you must think deeply about constructors, and the meaning of life
+// NOTE To solve this puzzle, you must think deeply about deploying new contracts, and the meaning of life
 
 contract TheMeaningOfLife {
 


### PR DESCRIPTION
This PR accomplishes the following:
- Adds a few more puzzles to Primitive Types for `bool` and `address` and `bytes`
- Refactors puzzle names to separate words with underscore `_`